### PR TITLE
Adding initial tech presentation format

### DIFF
--- a/support/templates/tech/template-presentation-format.tex
+++ b/support/templates/tech/template-presentation-format.tex
@@ -1,0 +1,560 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Define bibliography options
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Define the options for bibliography and load biblatex package
+\RequirePackage[
+   backend     = bibtex8, 
+   giveninits  = true, 
+   natbib      = true, 
+   style       = aiaa, 
+   autocite    = inline, 
+   bibwarn     = false]{biblatex}
+
+% Allows cite command to control autocite
+\let\cite\autocite
+
+\RequirePackage{ragged2e}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Define document format settings
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Set the geometry for each page
+\geometry{paperwidth=8.5in,paperheight=13.6in,top=0.66in,left=0.75in,right=0.75in,bottom=0.5in,includefoot,landscape}
+
+% Set new paragraph indentation to zero
+\setlength{\parindent}{0in}
+
+% Define paragraph skip sizes - space between paragraphs
+\setlength{\parskip}{12pt}
+
+% Create a section break after each "section"
+\let\oldsection\section
+\renewcommand\section{
+   \clearpage
+   \oldsection
+}
+
+% Custom fontsizes
+\renewcommand\normalsize{\@setfontsize\normalsize{16}{16}}
+\renewcommand\large{\@setfontsize\large{20}{20}}
+\renewcommand\Large{\@setfontsize\Large{24}{24}}
+\renewcommand\LARGE{\@setfontsize\LARGE{28}{28}}
+\renewcommand\huge{\@setfontsize\Huge{30}{30}}
+\renewcommand\Huge{\@setfontsize\Huge{34}{34}}
+
+\docExport[true]
+\docITAR[false]
+\docSBU[false]
+\docCUI[false]
+
+% Define that figures and tables are numbered based on section e.g. "Table X.X"
+\counterwithin{figure}{section}
+\counterwithin{table}{section}
+\counterwithin{equation}{section}
+% Note: counterwithin for lstlisting needs to happen after \begin{document}
+\AtBeginDocument{\counterwithin{lstlisting}{section}}
+
+% Define spacing between Section titles and text
+\titlespacing{\section}{0pt}{0.25\baselineskip}{0\baselineskip}
+\titlespacing{\subsection}{0pt}{0.25\baselineskip}{0\baselineskip}
+\titlespacing{\subsubsection}{0pt}{0.25\baselineskip}{0\baselineskip}
+\titlespacing{\paragraph}{0pt}{0.25\baselineskip}{0\baselineskip}
+\titlespacing{\subparagraph}{0pt}{0.25\baselineskip}{0\baselineskip}
+
+% This little function splits the last page computation between:
+   % roman: frontmatter
+   % arabic: mainmatter
+\newif\if@mainmatter
+\newcommand{\frontmatter}{%
+  \clearpage
+  \pagenumbering{roman}
+  \edef\computelastpage{%
+    \romannumeral\numexpr\getpagerefnumber{LastFrontPage}-1\relax}}
+\newcommand{\mainmatter}{%
+  \clearpage
+  \immediate\write\@auxout{\noexpand\newlabel{LastFrontPage}{{}{\arabic{page}}}}%
+  \@mainmattertrue
+  \pagenumbering{arabic}
+  \def\computelastpage{\pageref{LastPage}}}
+\newcommand{\backmatter}{%
+  \clearpage
+  \immediate\write\@auxout{\noexpand\newlabel{LastBackPage}{{}{\arabic{page}}}}%
+  \pagenumbering{Roman}
+  \edef\computelastpage{%
+  \romannumeral\numexpr\getpagerefnumber{LastBackPage}-1\relax}}
+
+% Set equation labels in brackets as opposed to parentheses
+\newtagform{brackets}{[}{]}
+\usetagform{brackets}
+
+% Remove space after figure and table environments
+\AfterEndEnvironment{table}{\vspace{-1\baselineskip}}
+\AfterEndEnvironment{figure}{\vspace{-1\baselineskip}}
+\AtBeginEnvironment{quote}{\vspace{-\baselineskip}}
+\AtEndEnvironment{quote}{\vspace{-\baselineskip}}
+\AtBeginEnvironment{center}{\vspace{-0.5\baselineskip}}
+\AtEndEnvironment{center}{\vspace{-0.5\baselineskip}}
+\AtBeginEnvironment{itemize}{\vspace{-0.5\baselineskip}}
+\AtEndEnvironment{itemize}{\vspace{-0.5\baselineskip}}
+\AtBeginEnvironment{enumerate}{\vspace{-0.5\baselineskip}}
+\AtEndEnvironment{enumerate}{\vspace{-0.5\baselineskip}}
+\AtEndEnvironment{listing}{\vspace{-\baselineskip}}
+
+% % Define the headheight - set to zero, no header in this format
+\setlength{\headheight}{0pt}
+% \setlength{\headsep}{0pt}
+% \setlength{\topmargin}{0pt}
+
+% % Modify the header and footer lines - set to zero to remove
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{1pt}
+
+\renewcommand{\PREprintbibliography}{\newpage}  
+\renewcommand{\PREprintNomenclature}{\newpage}  
+
+% Make the references fontsize small
+\renewcommand*{\bibfont}{\small}
+
+\newcommand{\TitlePageGeometry}{\newgeometry{top=0.5in,left=0.75in,right=0.75in,bottom=0.5in}}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Define document header and footer settings
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% Define size of the header/footer text
+\newcommand{\hfsize}{\footnotesize}
+
+% Create the Footer - Clear the current header/footer style
+\fancyhf{} 
+
+% Set the current header/footer style
+\pagestyle{fancy}
+
+% Footer
+\cfoot{\printExportFooter}
+
+% Right Footer
+\rfoot{\hfsize Page: \thepage \hspace{2pt} of \hspace{2pt} \begingroup\hypersetup{linkcolor=black}\computelastpage\endgroup}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Settings for TOC, LOF, LOT, Acronyms
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% This command adds dots in TOC for all entries (sections didnt have them)
+\renewcommand{\cftsecleader}{\cftdotfill{\cftdotsep}}
+% This command adds "Figure" to front of LoF entries
+% \renewcommand{\cftfigfont}{Figure }
+% This command adds "Table" to front of LoT entries
+%\renewcommand{\cfttabfont}{Table }
+
+% Change the space between dotted lines
+\renewcommand\cftdotsep{1.5}
+
+% Set the table of contents level depth
+\setcounter{tocdepth}{4}
+
+% Set the indent spacing
+\setlength{\cftsecindent}{0cm}
+\setlength{\cftsubsecindent}{0.5cm}
+\setlength{\cftsubsubsecindent}{1cm}
+\setlength{\cftparaindent}{1.5cm}
+\setlength{\cftsubparaindent}{2cm}
+
+% Create Table of Contents, ToC
+% Change font sizes in ToC
+\renewcommand\cftsecfont         {\fontsize{11pt}{6pt}\selectfont\bfseries}
+\renewcommand\cftsubsecfont      {\fontsize{10pt}{6pt}\selectfont}
+\renewcommand\cftsubsubsecfont   {\fontsize{10pt}{6pt}\selectfont}
+\renewcommand\cftparafont        {\fontsize{10pt}{6pt}\selectfont}
+\renewcommand\cftsubparafont     {\fontsize{10pt}{6pt}\selectfont}
+
+% Add some spacing so the section number and title dont overlap in TOC
+\setlength\cftsecnumwidth{1\baselineskip}
+\setlength\cftsubsecnumwidth{1.5\baselineskip}
+\setlength\cftsubsubsecnumwidth{2\baselineskip}
+\setlength\cftparanumwidth{2.5\baselineskip}
+\setlength\cftsubparanumwidth{3\baselineskip}
+\setlength{\cftbeforetoctitleskip}{1in}
+
+% Change font sizes in LoF and LoT
+\renewcommand\cftfigfont         {\fontsize{10pt}{6pt}\selectfont}
+\renewcommand\cfttabfont         {\fontsize{10pt}{6pt}\selectfont}
+
+% Add some spacing so the figure or table number and title dont overlap in LOF ot LOT
+\setlength\cftfignumwidth{35pt}
+\setlength\cfttabnumwidth{35pt}
+\setlength\cftfigindent{0pt}
+\setlength\cfttabindent{0pt}
+\setlength\cftbeforefigskip{0pt}
+\setlength\cftbeforetabskip{0pt}
+
+% Code listings have to be modified in a diffrent manner to match LOF and LOT format
+\AtBeginDocument{%
+\renewcommand\lstlistoflistings{\bgroup
+  \let\contentsname\lstlistlistingname
+  \def\l@lstlisting##1##2{\@dottedtocline{1}{1.5em}{42pt}{##1}{##2}}
+  \let\lst@temp\@starttoc \def\@starttoc##1{\lst@temp{lol}}%
+  \tableofcontents \egroup}
+}
+
+% Create List of Tables section separators
+% \renewcommand\cfttabfont\small
+% \preto\table{%
+%   \ifnum\value{table}=0\addtocontents{lot}{{\vskip\baselineskip}}\fi
+% }
+
+% % Create List of Figures section separators
+% \renewcommand\cftfigfont\small
+% \preto\figure{%
+%   \ifnum\value{figure}=0\addtocontents{lof}{{\vskip\baselineskip}}\fi
+% }
+
+% Make the list of acronyms
+\renewcommand{\glsnamefont}[1]{\textbf{#1}} % Set aronyms back to bold
+\renewcommand{\glossarypreamble}{\small} % Change fontsize
+\renewcommand{\arraystretch}{1.2}
+\setlength{\glspagelistwidth}{0.8\textwidth}
+\setlength{\glsdescwidth}{0.8\textwidth}
+\glssetwidest[0]{ALongPlaceHolder}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Update the settings for the appendix
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% This adds the \backmatter to the begining of appendices to change numbering
+\AtBeginEnvironment{appendices}{
+   % For page numbering - back to roman
+   % \backmatter
+
+   % For subsection numbering - use alphanumeric combination
+   \renewcommand{\thesubsection}{\thesection.\arabic{subsection}}
+
+   % This helps to setup pdf bookmarks for appendices
+   \titleformat{\section}{\normalfont\Large\bfseries\bookmarksetupnext{level=subsection}}{\thesection}{1em}{}
+   \titleformat{\subsection}{\normalfont\large\bfseries\bookmarksetupnext{level=subsubsection}}{\thesubsection}{1em}{}
+   \titleformat{\subsubsection}{\normalfont\normalsize\bfseries\bookmarksetupnext{level=paragraph}}{\thesubsubsection}{1em}{}
+   }
+   
+% \AtEndEnvironment{appendices}{\backmatter}
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Define custom content commands to be used in template file(s)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\renewcommand{\printLOA}{
+   \ifdefstring{\@docLOA}{true}{
+      % Change the glossary title to nothing, we will create our own
+      \renewcommand{\glossarysection}[2][]{}
+      \setlength{\parskip}{0.1\baselineskip}
+      \phantomsection
+      \bookmarksetupnext{level=subsection}
+      \addcontentsline{toc}{section}{Acronyms}
+      \slide{Acronyms}
+      \small\flushleft
+      \begin{multicols*}{2}
+      \printglossary[style=alttree,type=\acronymtype]
+      \end{multicols*}
+   }{}
+}
+
+
+\newcommand{\slide}[1]{
+    \clearpage
+   \phantomsection
+   \pdfbookmark[2]{#1}{#1}
+    \begin{minipage}{.17\textwidth}
+        \begin{flushleft}
+            \ifdefstring{\@docOrgLogo}{}{}{\includegraphics[height=1in]{\@docOrgLogo}}
+        \end{flushleft}
+    \end{minipage}%
+    \centering
+    \begin{minipage}{.64\textwidth}
+        \centering
+        \huge\textbf{#1}
+    \end{minipage}
+    \begin{minipage}{.17\textwidth}
+        \begin{flushright}
+            \ifdefstring{\@docLogo}{}{}{\includegraphics[height=1in]{\@docLogo}}
+        \end{flushright}
+    \end{minipage}
+    \vspace{12pt} \hrule height 2pt \vspace{6pt}
+}
+
+\renewcommand{\printExport}{
+   % SBU has been replaced with CUI
+   \ifdefstring{\@docSBU}{true}{\toggletrue{isCUI}}{} 
+   \ifdefstring{\@docITAR}{true}{\toggletrue{isCUI}}{} 
+   \ifdefstring{\@docCUI}{true}{\toggletrue{isCUI}}{} 
+
+   \newtoggle{printExport}
+   \ifdefstring{\@docITAR}{true}{\toggletrue{printExport}}{} 
+   \ifdefstring{\@docExportText}{}{}{\toggletrue{printExport}} 
+   \iftoggle{isCUI}{\toggletrue{printExport}}
+
+   % Include the Tech Report Export page
+   \iftoggle{printExport}{
+      % Add a PDF bookmark in PDF viewer 
+      \slide{EXPORT INFORMATION}
+      \phantomsection
+      \pdfbookmark[2]{Export Page}{export}
+      % Print the custom user defined export control text
+      \ifdefstring{\@docExportText}{}{}{
+          \vspace{0.25in}
+          \begin{center}
+              \fbox{
+              \begin{minipage}{5.95in}
+                  {\footnotesize\@docExportText}
+              \end{minipage}
+              }
+          \end{center}
+      }
+      % Print the CUI notice
+      \iftoggle{isCUI}{
+         \vspace{0.25in}
+         \begin{center}
+            \fbox{
+               \begin{minipage}{5.95in}
+                  \footnotesize%
+                  \input{cui.tex}%
+                  \ifdefstring{\@docCUIText}{}{}{\newline\newline\@docCUIText}{}%
+               \end{minipage}
+            }
+         \end{center}
+      }{}
+      % Print the ITAR notice
+      \ifdefstring{\@docITAR}{true}{
+          \vspace{0.25in}
+          \begin{center}
+              \fbox{
+              \begin{minipage}{5.95in}
+                  {\footnotesize\input{itar.tex}}
+              \end{minipage}
+              }
+          \end{center}
+      }{}
+   }{}
+}
+
+\newcommand{\printRevisionLog}{
+   \ifdefstring{\@docRevisionLog}{}{}{
+      \newpage \null
+      \phantomsection
+      \pdfbookmark[2]{Revision Log}{revision}
+
+      \begin{center}
+         \textbf{REVISION LOG}
+      \end{center}
+
+      \vspace{0.25in}
+
+      \ifdefstring{\@docRevisionLog}{default}{
+         \small\textnormal
+         {\color{input}\textbackslash docRevisionLog[}\\
+         {\color{input}\hspace{0.25in}\textbackslash begin\{versionhistory\}}\\
+         {\color{input}\hspace{0.25in}\textbackslash vhEntry\{{\color{black}\small\it revision}\}\{{\color{black}\small\it date}\}\{{\color{black}\small\it author}\}\{{\color{black}\small\it description}\}}\\
+         {\color{input}\hspace{0.25in}\textbackslash vhEntry\{{\color{black}\small\it revision}\}\{{\color{black}\small\it date}\}\{{\color{black}\small\it author}\}\{{\color{black}\small\it description}\}}\\
+         {\color{input}\hspace{0.25in}\textbackslash end\{versionhistory\}}\\
+         {\color{input}]}
+      }{
+         \@docRevisionLog      
+      }
+   }
+}
+
+\newcommand{\printExecutiveSummary}{
+   \ifdefstring{\@docAbstract}{}{}{
+      \newpage \null
+      \phantomsection
+      \pdfbookmark[2]{Executive Summary}{execsummary}
+
+      \begin{center}
+         \textbf{EXECUTIVE SUMMARY}
+      \end{center}
+
+      \vspace{\baselineskip}
+
+      \@docAbstract      
+   }
+}
+
+\newcommand{\printAuthorPage}{
+\checkdocAuthorName(1)
+\ifemptydata
+  % If not input for docContributorName(1), skip entire section
+\else
+   \newpage \null
+   \phantomsection
+   \pdfbookmark[2]{Author Page}{author}
+
+   \begin{center}
+    \textbf{AUTHOR PAGE}
+   \end{center}
+
+   \textbf{Presented by:} \vspace{6pt}
+
+   \multido{\ii=1+2}{10}{%
+    \checkdocAuthorName(\ii)
+    \ifemptydata
+       % \docAuthor not defined for this index, skip
+    \else
+       \begin{minipage}{.48\textwidth}%
+       \ifdefstring{\@docSigned}{true}{
+          \textit{/s/ \docAuthorName(\ii)} \hfill \@docSignDate 
+       }{
+          \textit{\small To Sign:} 
+          {\small\textnormal{\color{input}\textbackslash docSigned[{\color{black} true}]}}
+          {\small\textnormal{\color{input}\textbackslash docSignDate[{\color{black} date}]}}  
+       }  
+       \vspace{6pt} \hrule \vspace{5pt}
+       \small\textbf{\docAuthorName(\ii)} \hfill \textbf{Date} \break
+       \docAuthorPosition(\ii) \hfill \break
+       \docAuthorOrganization(\ii) \hfill \break
+       \docAuthorLocation(\ii) \hfill 
+       \end{minipage}%
+       \begin{minipage}{.01\textwidth}%
+       \hfill
+       \end{minipage}%
+       \edef\iinext{\number\numexpr\ii+1\relax}
+       \checkdocAuthorName(\iinext)
+       \ifemptydata
+          \vspace{12pt}
+          \break
+       \else
+          \begin{minipage}{.48\textwidth}%
+          \ifdefstring{\@docSigned}{true}{
+             \textit{/s/ \docAuthorName(\iinext)} \hfill \@docSignDate 
+          }{
+            \textit{\small To Sign:} 
+            {\small\textnormal{\color{input}\textbackslash docSigned[{\color{black} true}]}}
+            {\small\textnormal{\color{input}\textbackslash docSignDate[{\color{black} date}]}} 
+          }  
+            \vspace{6pt} \hrule \vspace{5pt}
+            \small\textbf{\docAuthorName(\iinext)} \hfill \textbf{Date} \break
+            \docAuthorPosition(\iinext) \hfill \break
+            \docAuthorOrganization(\iinext) \hfill \break
+            \docAuthorLocation(\iinext) \hfill 
+            \end{minipage}%
+            \hfill
+            \vspace{12pt}
+       \fi    
+    \fi   
+   }
+\fi     
+}
+
+\newcommand{\printApproverPage}{
+\checkdocApproverName(1)
+\ifemptydata
+ % If not input for docContributorName(1), skip entire section
+\else
+   \newpage \null
+   \phantomsection
+   \pdfbookmark[2]{Signature Page}{signature}
+
+   \begin{center}
+   \textbf{SIGNATURE PAGE}
+   \end{center}
+
+   \textbf{Presented to:} \vspace{6pt}
+
+   \multido{\ii=1+2}{10}{%
+   \checkdocApproverName(\ii)
+   \ifemptydata
+    % \docAuthor not defined for this index, skip
+   \else
+    \begin{minipage}{.48\textwidth}%
+    \ifdefstring{\@docSigned}{true}{
+       \textit{/s/ \docApproverName(\ii)} \hfill \@docSignDate 
+    }{
+       \textit{\small To Sign:} 
+       {\small\textnormal{\color{input}\textbackslash docSigned[{\color{black} true}]}}
+       {\small\textnormal{\color{input}\textbackslash docSignDate[{\color{black} date}]}}  
+    }  
+    \vspace{6pt} \hrule \vspace{5pt}
+    \small\textbf{\docApproverName(\ii)} \hfill \textbf{Date} \break
+    \docApproverPosition(\ii) \hfill \break
+    \docApproverOrganization(\ii) \hfill \break
+    \docApproverLocation(\ii) \hfill 
+    \end{minipage}%
+    \begin{minipage}{.01\textwidth}%
+    \hfill
+    \end{minipage}%
+    \edef\iinext{\number\numexpr\ii+1\relax}
+    \checkdocApproverName(\iinext)
+    \ifemptydata
+       \vspace{12pt}
+       \break
+    \else
+       \begin{minipage}{.48\textwidth}%
+       \ifdefstring{\@docSigned}{true}{
+          \textit{/s/ \docApproverName(\iinext)} \hfill \@docSignDate 
+       }{
+         \textit{\small To Sign:} 
+         {\small\textnormal{\color{input}\textbackslash docSigned[{\color{black} true}]}}
+         {\small\textnormal{\color{input}\textbackslash docSignDate[{\color{black} date}]}} 
+       }  
+         \vspace{6pt} \hrule \vspace{5pt}
+         \small\textbf{\docApproverName(\iinext)} \hfill \textbf{Date} \break
+         \docApproverPosition(\iinext) \hfill \break
+         \docApproverOrganization(\iinext) \hfill \break
+         \docApproverLocation(\iinext) \hfill 
+         \end{minipage}%
+         \hfill
+         \vspace{12pt}
+    \fi    
+   \fi   
+   }
+\fi     
+}
+
+\newcommand{\printContributorPage}{
+\checkdocContributorName(1)
+\ifemptydata
+  % If not input for docContributorName(1), skip entire section
+\else
+   \newpage \null
+   \phantomsection
+   \pdfbookmark[2]{Contributor Page}{contributor}
+
+   \begin{center}
+   \textbf{CONTRIBUTOR PAGE}
+   \end{center}
+
+   \textbf{Contributors:} \vspace{6pt}
+
+   \multido{\ii=1+2}{10}{%
+   \checkdocContributorName(\ii)
+   \ifemptydata
+      % \docAuthor not defined for this index, skip
+   \else
+      \begin{minipage}{.48\textwidth}%
+      \textbf{\docContributorName(\ii)} \hfill \break
+      \docContributorPosition(\ii) \hfill \break
+      \docContributorOrganization(\ii) \hfill \break
+      \docContributorLocation(\ii) \hfill 
+      \end{minipage}%
+      \begin{minipage}{.01\textwidth}%
+      \hfill
+      \end{minipage}%
+      \edef\iinext{\number\numexpr\ii+1\relax}
+      \checkdocContributorName(\iinext)
+      \ifemptydata
+         \vspace{12pt}
+         \break
+      \else
+         \begin{minipage}{.48\textwidth}%
+         \textbf{\docContributorName(\iinext)} \hfill \break
+         \docContributorPosition(\iinext) \hfill \break
+         \docContributorOrganization(\iinext) \hfill \break
+         \docContributorLocation(\iinext) \hfill 
+         \end{minipage}%
+         \hfill
+         \vspace{12pt}
+      \fi    
+   \fi   
+   }
+\fi  
+}

--- a/support/templates/tech/template-tech-presentation.tex
+++ b/support/templates/tech/template-tech-presentation.tex
@@ -1,0 +1,151 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TEMPLATE: Insert the AIAA document parameters - provided by the user
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\input{template-presentation-format}
+
+% Enable various page flags
+\docTOC[false]
+\docLOF[false]
+\docLOT[false]
+\docLOL[false]
+\docLOA[false]
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% SECTION: Create all the front matter prior to user content
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\AtBeginDocument{
+
+   % Add a PDF bookmark in PDF viewer for all of front matter
+   \pdfbookmark[1]{Front Matter}{front}
+
+   \frontmatter
+
+   % Add cover sheet only if defined
+   \ifdefstring{\@docCoverSheet}{}{}{\toggletrue{addCoverPage}}
+   \ifdefstring{\@docCUICoverSheet}{}{}{\toggletrue{addCoverPage}}
+   \iftoggle{addCoverPage}{
+      \newpage \clearpage \thispagestyle{empty}
+      \addtocounter{page}{-2}
+      \printCoverPage
+      \newpage \clearpage \thispagestyle{empty}
+   }{ 
+      \newpage \clearpage \thispagestyle{empty}
+      \addtocounter{page}{-1}
+   }
+
+   \phantomsection
+   \pdfbookmark[2]{Title Page}{titlepage}
+
+   \TitlePageGeometry
+
+   \begin{minipage}{.22\textwidth}
+      \begin{flushleft}
+      \ifdefstring{\@docOrgLogo}{}{}{\includegraphics[height=1in]{\@docOrgLogo}}
+      \end{flushleft}
+   \end{minipage}%
+   \begin{minipage}{.55\textwidth}
+      \centering%
+      \iftoggle{isCUI}{
+         \footnotesize\textbf{CUI}%
+         \ifdefstring{\@docCUICategoryMarkings}{}{}{\footnotesize\textbf{//\@docCUICategoryMarkings\\\vspace{0.1in}}}%
+      }{}%
+      \large\textbf{\@docTypeTitle \\ \vspace{6pt} Technical Presentation}
+   \end{minipage}
+   \begin{minipage}{.22\textwidth}
+      \begin{flushright}
+         \ifdefstring{\@docLogo}{}{}{\includegraphics[height=1in]{\@docLogo}}
+      \end{flushright}
+   \end{minipage}
+
+   \vspace{0.35in}
+
+   \textbf{Date:}  \@docDate \hfill \ifdefstring{\@docNumber}{}{}{\textbf{Document Number:} \@docNumber} 
+
+   \textbf{Title:} \@docTitle
+
+   % Draw black line
+   \vspace{12pt} \hrule height 2pt \vspace{6pt}
+
+   \textbf{\large Agenda:}
+
+   \@docAbstract
+   
+   % fill in empty space
+   \vfill
+   
+   % Create the author information section
+   \begin{minipage}{.48\textwidth}%
+      \textbf{Presented by:} \vspace{2mm}
+      
+      \vspace{6pt} \hrule \vspace{5pt}
+      \small\textbf{\docAuthorName(1)} \hfill \break
+      \docAuthorPosition(1) \hfill \break
+      \docAuthorOrganization(1) \hfill \break
+      \docAuthorLocation(1) \hfill 
+      \end{minipage}%
+      \begin{minipage}{.01\textwidth}%
+      \hfill
+   \end{minipage}%
+   % Create the audience information section
+   \begin{minipage}{.48\textwidth}%
+      \textbf{Presented to:} \vspace{2mm}
+      
+      \vspace{9.5pt} \hrule \vspace{5pt}
+      \small\textbf{\docApproverName(1)} \hfill \break
+      \docApproverPosition(1) \hfill \break
+      \docApproverOrganization(1) \hfill \break
+      \docApproverLocation(1) \hfill 
+      \end{minipage}%
+      \begin{minipage}{.01\textwidth}%
+      \hfill
+   \end{minipage}%
+   
+   \vspace{\baselineskip}
+
+   \begin{center}
+      \printExportFooter
+   \end{center}
+
+   \vspace{0.25in} 
+
+   % Change the geometry back
+   \restoregeometry
+
+   % Print the export control information section
+   \printExport
+
+   % Print the revision log page
+   \printRevisionLog
+
+   % Create the Table of Contents
+   \printTOC
+
+   % Create the List of Tables
+   \printLOT
+
+   % Create the List of Figures
+   \printLOF
+
+   % Create the List of Listings
+   \printLOL
+
+   % Create the List of Acronyms
+   \printLOA
+
+   % Create the Nomenclature definition section
+   \printNomenclature
+
+   % remove padding to row height as to no affect other tables
+   \setlength\extrarowheight{0pt} 
+
+   \mainmatter
+
+   % Make all text justified and normalsize
+   \justifying\normalsize
+
+   % Set paragraph indent to zero
+   \setlength{\parindent}{0pt}
+
+}


### PR DESCRIPTION
Users can use `template=tech-presentation` to use this new presentation template. A new `\slide` command can be used to create a page that _looks_ like the title page, but has empty contents to allow users to fill in their own content.

**Example Slide Usage:**
```
\slide{My Slide Title}{
  \flushleft\textbf{\Large Some Excellent Points}
  \vspace{1em}
  \begin{itemize}
    \item My first point...
    \item A second point...
    \item And another point...
  \end{itemize}
}
```

Note that the end goal would be to overload `\section` in the `tech-presentation` template, but I wasn't able to make that work, so `\slide` was a helpful workaround in the short term.

Out of the box, the title slide looks like this...
<img width="1652" alt="Screen Shot 2022-01-12 at 5 45 50 PM" src="https://user-images.githubusercontent.com/96269213/149235075-f73f7b9a-9e63-49c2-9bf6-697a2839cae3.png">

